### PR TITLE
Create Compat: upright_on_belt and mixing recipes.

### DIFF
--- a/src/main/resources/data/marbledsfirstaid/create/tags/upright_on_belt.json
+++ b/src/main/resources/data/marbledsfirstaid/create/tags/upright_on_belt.json
@@ -1,0 +1,12 @@
+{
+  "values": [
+    "marbledsfirstaid:adrenaline_syringe",
+    "marbledsfirstaid:morphine_syringe",
+    "marbledsfirstaid:stimpack",
+    "marbledsfirstaid:morphine",
+    "marbledsfirstaid:eye_drops",
+    "marbledsfirstaid:tonic",
+    "marbledsfirstaid:antidote",
+    "marbledsfirstaid:elixir"
+  ]
+}

--- a/src/main/resources/data/marbledsfirstaid/recipes/create_compat/adrenaline_syringe_mixing.json
+++ b/src/main/resources/data/marbledsfirstaid/recipes/create_compat/adrenaline_syringe_mixing.json
@@ -1,0 +1,17 @@
+{
+  "type": "create:mixing",
+  "heatRequirement": "heated",
+  "ingredients": [
+    {
+      "item": "marbledsfirstaid:awkward_syringe"
+    },
+    {
+      "item": "minecraft:rabbit_foot"
+    }
+  ],
+  "results": [
+    {
+      "item": "marbledsfirstaid:adrenaline_syringe"
+    }
+  ]
+}

--- a/src/main/resources/data/marbledsfirstaid/recipes/create_compat/antidote_mixing.json
+++ b/src/main/resources/data/marbledsfirstaid/recipes/create_compat/antidote_mixing.json
@@ -1,0 +1,17 @@
+{
+  "type": "create:mixing",
+  "heatRequirement": "heated",
+  "ingredients": [
+    {
+      "item": "marbledsfirstaid:awkward_medicine_bottle"
+    },
+    {
+      "item": "minecraft:copper_ingot"
+    }
+  ],
+  "results": [
+    {
+      "item": "marbledsfirstaid:antidote"
+    }
+  ]
+}

--- a/src/main/resources/data/marbledsfirstaid/recipes/create_compat/awkward_medicine_bottle_mixing.json
+++ b/src/main/resources/data/marbledsfirstaid/recipes/create_compat/awkward_medicine_bottle_mixing.json
@@ -1,0 +1,21 @@
+{
+  "type": "create:mixing",
+  "heatRequirement": "heated",
+  "ingredients": [
+    {
+      "amount": 250,
+      "fluid": "minecraft:potion",
+      "nbt":{
+        "Potion": "minecraft:awkward"
+      }
+    },
+    {
+      "item": "marbledsfirstaid:medicine_bottle"
+    }
+  ],
+  "results": [
+    {
+      "item": "marbledsfirstaid:awkward_medicine_bottle"
+    }
+  ]
+}

--- a/src/main/resources/data/marbledsfirstaid/recipes/create_compat/awkward_syringe_mixing.json
+++ b/src/main/resources/data/marbledsfirstaid/recipes/create_compat/awkward_syringe_mixing.json
@@ -1,0 +1,21 @@
+{
+  "type": "create:mixing",
+  "heatRequirement": "heated",
+  "ingredients": [
+    {
+      "amount": 250,
+      "fluid": "minecraft:potion",
+      "nbt":{
+        "Potion": "minecraft:awkward"
+      }
+    },
+    {
+      "item": "marbledsfirstaid:syringe"
+    }
+  ],
+  "results": [
+    {
+      "item": "marbledsfirstaid:awkward_syringe"
+    }
+  ]
+}

--- a/src/main/resources/data/marbledsfirstaid/recipes/create_compat/elixir_mixing.json
+++ b/src/main/resources/data/marbledsfirstaid/recipes/create_compat/elixir_mixing.json
@@ -1,0 +1,17 @@
+{
+  "type": "create:mixing",
+  "heatRequirement": "heated",
+  "ingredients": [
+    {
+      "item": "marbledsfirstaid:awkward_medicine_bottle"
+    },
+    {
+      "item": "minecraft:iron_ingot"
+    }
+  ],
+  "results": [
+    {
+      "item": "marbledsfirstaid:elixir"
+    }
+  ]
+}

--- a/src/main/resources/data/marbledsfirstaid/recipes/create_compat/eye_drops_mixing.json
+++ b/src/main/resources/data/marbledsfirstaid/recipes/create_compat/eye_drops_mixing.json
@@ -1,0 +1,17 @@
+{
+  "type": "create:mixing",
+  "heatRequirement": "heated",
+  "ingredients": [
+    {
+      "item": "marbledsfirstaid:awkward_medicine_bottle"
+    },
+    {
+      "item": "minecraft:bone_meal"
+    }
+  ],
+  "results": [
+    {
+      "item": "marbledsfirstaid:eye_drops"
+    }
+  ]
+}

--- a/src/main/resources/data/marbledsfirstaid/recipes/create_compat/morphine_mixing.json
+++ b/src/main/resources/data/marbledsfirstaid/recipes/create_compat/morphine_mixing.json
@@ -1,0 +1,17 @@
+{
+  "type": "create:mixing",
+  "heatRequirement": "heated",
+  "ingredients": [
+    {
+      "item": "marbledsfirstaid:awkward_medicine_bottle"
+    },
+    {
+      "item": "minecraft:fermented_spider_eye"
+    }
+  ],
+  "results": [
+    {
+      "item": "marbledsfirstaid:antidote"
+    }
+  ]
+}

--- a/src/main/resources/data/marbledsfirstaid/recipes/create_compat/morphine_syringe_mixing.json
+++ b/src/main/resources/data/marbledsfirstaid/recipes/create_compat/morphine_syringe_mixing.json
@@ -1,0 +1,17 @@
+{
+  "type": "create:mixing",
+  "heatRequirement": "heated",
+  "ingredients": [
+    {
+      "item": "marbledsfirstaid:awkward_syringe"
+    },
+    {
+      "item": "minecraft:fermented_spider_eye"
+    }
+  ],
+  "results": [
+    {
+      "item": "marbledsfirstaid:morphine_syringe"
+    }
+  ]
+}

--- a/src/main/resources/data/marbledsfirstaid/recipes/create_compat/stimpack_mixing.json
+++ b/src/main/resources/data/marbledsfirstaid/recipes/create_compat/stimpack_mixing.json
@@ -1,0 +1,17 @@
+{
+  "type": "create:mixing",
+  "heatRequirement": "heated",
+  "ingredients": [
+    {
+      "item": "marbledsfirstaid:awkward_syringe"
+    },
+    {
+      "item": "minecraft:glowstone_dust"
+    }
+  ],
+  "results": [
+    {
+      "item": "marbledsfirstaid:stimpack"
+    }
+  ]
+}

--- a/src/main/resources/data/marbledsfirstaid/recipes/create_compat/tonic_mixing.json
+++ b/src/main/resources/data/marbledsfirstaid/recipes/create_compat/tonic_mixing.json
@@ -1,0 +1,17 @@
+{
+  "type": "create:mixing",
+  "heatRequirement": "heated",
+  "ingredients": [
+    {
+      "item": "marbledsfirstaid:awkward_medicine_bottle"
+    },
+    {
+      "item": "minecraft:amethyst_shard"
+    }
+  ],
+  "results": [
+    {
+      "item": "marbledsfirstaid:tonic"
+    }
+  ]
+}


### PR DESCRIPTION
Title. 

1. Adds Create's upright_on_belt tag to MFA bottles and syringes, with the idea that this would allow them to be used in spouting recipes at a later date.

![image](https://github.com/user-attachments/assets/8f7c5d62-6ecb-4305-83c5-948a2d4607af)
-# Screenshot of the #create:upright_on_belt tag in action. Taken without the changes present in this PR.

Would change items included in the PR (medicine bottles and derivatives, syringes) from laying flat on belts and depots (see stimpack in above screenshot) to stand vertically like the bottle (see bottle in above screenshot).

2. Adds mixing recipes that require heating for all recipes requiring brewing (bottles, syringes).

Awkward potion bottles were substituted for 250mb minecraft:potion with minecraft:awkward nbt as necessary to be more in keeping with Create's style.

This doesn't add new content to your mod or change how items are obtained; it simply allows them to be automated via Create like every craft-able item in your mod currently is.

Please let me know your feedback and if there's anything that needs changing before you can approve this.